### PR TITLE
Add an option to only use the auction price for items that are likely to be sold

### DIFF
--- a/FarmLogOptions.lua
+++ b/FarmLogOptions.lua
@@ -186,6 +186,10 @@ UIDropDownMenu_Initialize(mfpanel.AHMinQualityDropdown, function (frame, level, 
 	end 
 end)
 
+mfpanel.AHMinQuantitySold = CreateCheckButton("FarmLogOptions_AHMinQuantitySold", mfpanel, L["minQuantitySold"])
+mfpanel.AHMinQuantitySold:SetPoint("TOPLEFT", mfpanel.AHMinQualityDropdown, "BOTTOMLEFT", 20, -12)
+mfpanel.AHMinQuantitySold:SetScript("OnClick", function(self) FLogGlobalVars.minQuantitySold = self:GetChecked() end)
+mfpanel.AHMinQuantitySold.tooltipText = L["minQuantitySold-tooltip"]
 
 ----------------------------------------------
 -- Tracking
@@ -193,7 +197,7 @@ end)
 mfpanel.TrackingCategoryTitle = mfpanel:CreateFontString(nil, 'ARTWORK', 'GameFontNormal')
 mfpanel.TrackingCategoryTitle:SetFont(font, 16)
 mfpanel.TrackingCategoryTitle:SetText(L["Tracking"])
-mfpanel.TrackingCategoryTitle:SetPoint("TOPLEFT", mfpanel.AHMinQualityDropdown, "BOTTOMLEFT", 20, -20)
+mfpanel.TrackingCategoryTitle:SetPoint("TOPLEFT", mfpanel.AHMinQuantitySold, "BOTTOMLEFT", 0, -20)
 
 mfpanel.TrackKills = CreateCheckButton("FarmLogOptions_TrackKills", mfpanel, L["Mobs Kill Count"])
 mfpanel.TrackKills:SetPoint("TOPLEFT", mfpanel.TrackingCategoryTitle, "BOTTOMLEFT", 0, -8)
@@ -331,6 +335,7 @@ function InterfacePanel:AddonLoaded()
 	InterfacePanel.MainFrame.PauseOnLogin:SetChecked(FLogGlobalVars.pauseOnLogin)
 	InterfacePanel.MainFrame.HonorDRinBGs:SetChecked(FLogGlobalVars.honorDRinBGs)
 	InterfacePanel.MainFrame.AutoResumeBGs:SetChecked(FLogGlobalVars.autoResumeBGs)
+	InterfacePanel.MainFrame.AHMinQuantitySold:SetChecked(FLogGlobalVars.minQuantitySold)
 
 	InterfacePanel.MainFrame.TrackLoot:SetChecked(FLogGlobalVars.track.drops)
 	InterfacePanel.MainFrame.TrackKills:SetChecked(FLogGlobalVars.track.kills)

--- a/Localization.lua
+++ b/Localization.lua
@@ -130,6 +130,8 @@ function FarmLog_BuildLocalization(context)
     L["options-help-sessions"] = "You can switch between farms with |cff00ff00/fl w DM Lashers|r or |cff00ff00/fl w BRM PvP|r etc., your previous data will be saved. View all farm sessions using the top left button (F) on the main log window."
     L["Prices"] = "Prices"
     L["AH Min Quality"] = "AH Min Quality"
+    L["minQuantitySold"] = "Only use the auction price for items that are likely to be sold"
+    L["minQuantitySold-tooltip"] = "Only has an effect if you have TSM installed. Use the auction price\nonly for items that have a Region Avg Daily Sold value greater\nor equal to 1."
     L["ah-quality-0"] = "No filter (gray+)"
     L["ah-quality-1"] = "Common (white+)"
     L["ah-quality-2"] = "Uncommon (green+)"


### PR DESCRIPTION
Add a config value `minQuantitySold`. By default, it's false. If it is set to true, `FarmLog:GetItemValue` will return the vendor value instead of the auction value if the TSM `avg daily sold` value is lower than 1.

This changes basically give a more realistic `gold/hour` estimation since green items for example never sell in the auction house and will most likely be vendored.